### PR TITLE
Revert "Release for v0.2.8"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-## [v0.2.8](https://github.com/Rindrics/aws-cost-cli/compare/v0.2.7...v0.2.8) - 2024-06-03
-- Enable role base access to fetch cost information by @Rindrics in https://github.com/Rindrics/aws-cost-cli/pull/24
-- Accept raw account ID as `--target-account` to query another account under organization by @Rindrics in https://github.com/Rindrics/aws-cost-cli/pull/26
-
 ## [v0.2.7](https://github.com/Rindrics/aws-cost-cli/compare/0.2.6...v0.2.7) - 2024-06-01
 - Run CI on pull request by @Rindrics in https://github.com/Rindrics/aws-cost-cli/pull/1
 - Add missing newline by @Rindrics in https://github.com/Rindrics/aws-cost-cli/pull/2


### PR DESCRIPTION
because I want to add `v0.3.0`

Reverts Rindrics/aws-cost-cli#25